### PR TITLE
Update to later version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,7 @@ defaultContentLanguage = "en"
 theme = "hugo-scroll"
 
 # The browser tab name
-title = "Global Hackathon | Hamburg"
+title = "Global Hackathon | Hamburg, DE"
 
 # In order to add version information in the page's footer set to true.
 # enableGitInfo = true

--- a/themes/hugo-scroll/layouts/partials/head.html
+++ b/themes/hugo-scroll/layouts/partials/head.html
@@ -24,7 +24,7 @@
 {{ $stylesheetFonts := resources.Get "css/fonts.css" }}
 {{ $stylesheetGeneric := resources.Get "css/generic.css" }}
 
-{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | resources.ToCSS ) }}
+{{ $stylesheetScreen := ( resources.Get "css/_index.scss" | css.Sass ) }}
 
 {{ $stylesheet := slice $stylesheetNormalize $stylesheetFA $stylesheetFonts $stylesheetGeneric $stylesheetScreen | resources.Concat "css/style.css" | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $stylesheet.Permalink }}" type="text/css" integrity="{{ $stylesheet.Data.Integrity }}" />


### PR DESCRIPTION
Hugo deprecated resources.ToCSS in v0.128.0 and removed it in later versions. Now, you need to replace it with css.Sass.